### PR TITLE
Result型とエラーハンドリングドキュメント追加

### DIFF
--- a/apps/app/src/utils/divide.ts
+++ b/apps/app/src/utils/divide.ts
@@ -1,0 +1,30 @@
+import { Result } from './result'
+
+/**
+ * 除算を安全に行う関数
+ *
+ * @description 0で割る場合はエラーを返します。
+ *
+ * @param dividend - 被除数
+ * @param divisor - 除数
+ * @returns 成功時は商、失敗時はエラーメッセージを含むResult
+ *
+ * @example
+ * ```typescript
+ * const result = divide(6, 3)
+ * if (result.ok) {
+ *   console.log(result.value) // 2
+ * } else {
+ *   console.error(result.error)
+ * }
+ * ```
+ */
+export const divide = (
+  dividend: number,
+  divisor: number
+): Result<number, string> => {
+  if (divisor === 0) {
+    return { ok: false, error: '0では割り算できません' }
+  }
+  return { ok: true, value: dividend / divisor }
+}

--- a/apps/app/src/utils/result.ts
+++ b/apps/app/src/utils/result.ts
@@ -1,0 +1,34 @@
+/**
+ * Result型
+ *
+ * @description 成功時と失敗時の値を型安全に扱うための共通型です。
+ * try/catch に頼らず、戻り値で成功・失敗を表現します。
+ *
+ * @typeParam T - 成功時の値の型
+ * @typeParam E - 失敗時のエラー型
+ */
+export type Result<T, E> = Success<T> | Failure<E>
+
+/**
+ * 成功を表す型
+ *
+ * @typeParam T - 成功値の型
+ */
+export interface Success<T> {
+  /** 成功フラグ */
+  ok: true
+  /** 成功時の値 */
+  value: T
+}
+
+/**
+ * 失敗を表す型
+ *
+ * @typeParam E - エラー値の型
+ */
+export interface Failure<E> {
+  /** 失敗フラグ */
+  ok: false
+  /** エラー情報 */
+  error: E
+}

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -182,6 +182,29 @@ throw new Error('ユーザー認証に失敗しました。メールアドレス
 throw new Error('エラーが発生しました')
 ```
 
+### Result型の利用
+
+エラーを例外として扱うのではなく、`Result`型で成功・失敗を明示的に返す実装を推奨します。
+
+```typescript
+import { divide } from '@/utils/divide'
+
+const result = divide(10, 2)
+if (result.ok) {
+  console.log(result.value)
+} else {
+  console.error(result.error)
+}
+```
+
+`Result`型の定義例は次のとおりです。
+
+```typescript
+export type Result<T, E> =
+  | { ok: true; value: T }
+  | { ok: false; error: E }
+```
+
 ### 避けるべきパターン
 - **過度な最適化**: 必要のない早期最適化
 - **deep nesting**: 5階層を超えるネスト構造


### PR DESCRIPTION
## Summary
- Result型を定義
- divide関数を追加しResult型の利用例を実装
- 開発ドキュメントにResult型利用方針とサンプルコードを追記

## Testing
- `pnpm typedoc`
- `pnpm lint`
- `pnpm run format:check`
- `pnpm type-check`
- `pnpm build`
- `pnpm exec turbo run test -- --passWithNoTests` *(失敗)*

------
https://chatgpt.com/codex/tasks/task_e_6841b02d4c388326acc0f2c5be69c1ad