### PR TITLE
vite設定にtsconfigパス解決を追加

### DIFF
--- a/apps/app/.prettierignore
+++ b/apps/app/.prettierignore
@@ -12,3 +12,6 @@ node_modules/
 
 # Logs
 *.log
+
+# APIドキュメント
+docs-api/

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -54,6 +54,7 @@
     "typescript": "5.8.3",
     "vite": "6.3.5",
     "vite-bundle-analyzer": "0.22.0",
+    "vite-tsconfig-paths": "^5.1.4",
     "vitest": "3.2.2",
     "yaml": "2.8.0"
   }

--- a/apps/app/tsconfig.json
+++ b/apps/app/tsconfig.json
@@ -13,6 +13,10 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
 
     /* Linting */
     "strict": true,

--- a/apps/app/tsconfig.node.json
+++ b/apps/app/tsconfig.node.json
@@ -4,7 +4,11 @@
     "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["vite.config.ts"]
 }

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import tsconfigPaths from 'vite-tsconfig-paths'
 import { visualizer } from 'rollup-plugin-visualizer'
 
 // https://vitejs.dev/config/
@@ -8,6 +9,7 @@ export default defineConfig({
   base: process.env.GITHUB_PAGES === 'true' ? '/study_github_agent/' : '/',
   plugins: [
     react(),
+    tsconfigPaths(),
     // バンドル分析を有効にする場合のみvisualizerプラグインを追加
     ...(process.env.ANALYZE === 'true'
       ? [


### PR DESCRIPTION
## Summary
- vite-tsconfig-paths を追加
- Vite設定でパスエイリアス `@/` を利用可能に
- tsconfig に paths 設定を追加
- API ドキュメントを Prettier 対象外に設定

## Testing
- `pnpm fullcheck`
- `pnpm typedoc`


------
https://chatgpt.com/codex/tasks/task_e_6841b8e48a1c8326a2e1a7abbf08baf3