### PR TITLE
テストレポートをCloudflare Pagesへ公開

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,3 +434,38 @@ jobs:
           name: playwright-html-report-${{ github.event.pull_request.number }}
           path: apps/app/playwright-report/
           retention-days: 14
+
+      - name: レポートをCloudflare Pages用に整理（PR時のみ）
+        if: always() && github.event_name == 'pull_request'
+        run: |
+          mkdir -p reports/vitest reports/playwright
+          cp apps/app/bundle-report.html reports/
+          cp -r apps/app/test-results/* reports/vitest/
+          cp -r apps/app/playwright-report/* reports/playwright/
+
+      - name: レポートをCloudflare Pagesへデプロイ（PR時のみ）
+        if: always() && github.event_name == 'pull_request'
+        uses: cloudflare/wrangler-action@v3
+        id: deploy-reports
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy reports --project-name=study-github-agent-reports --branch=pr-${{ github.event.pull_request.number }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: PRにレポートURLをコメント（PR時のみ）
+        if: always() && github.event_name == 'pull_request'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ## 📊 テストレポート公開完了
+
+            以下のレポートがCloudflare Pagesにデプロイされました。
+
+            - **URL**: ${{ steps.deploy-reports.outputs.deployment-url }}
+            - **Vitestレポート**: `vitest/index.html`
+            - **Playwrightレポート**: `playwright/index.html`
+            - **バンドル分析**: `bundle-report.html`
+
+            プレビューURLから各レポートを確認してください。

--- a/docs/deployment/ci-cd.md
+++ b/docs/deployment/ci-cd.md
@@ -225,6 +225,33 @@
 - **本番環境**: https://study-github-agent.pages.dev
 - **プレビュー環境**: https://{branch-name}--study-github-agent.pages.dev
 
+### Cloudflare Pages レポート公開
+Pull Request 時に生成されるテストレポートとバンドル分析レポートを
+Cloudflare Pages にデプロイして共有します。
+
+```yaml
+- name: Copy reports
+  if: always() && github.event_name == 'pull_request'
+  run: |
+    mkdir -p reports/vitest reports/playwright
+    cp apps/app/bundle-report.html reports/
+    cp -r apps/app/test-results/* reports/vitest/
+    cp -r apps/app/playwright-report/* reports/playwright/
+
+- name: Deploy reports to Cloudflare Pages
+  if: always() && github.event_name == 'pull_request'
+  uses: cloudflare/wrangler-action@v3
+  with:
+    apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+    accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    command: pages deploy reports --project-name=study-github-agent-reports --branch=${{ github.head_ref }}
+```
+
+**機能**:
+- Vitest、Playwright、バンドル分析レポートをまとめて公開
+- PRごとに独立したURLで確認可能
+- PRコメントに公開URLを自動通知
+
 ## リリース自動化
 
 ### GitHub Release作成


### PR DESCRIPTION
## 変更内容
- CI ワークフローで Vitest/Playwright/バンドル分析レポートを Cloudflare Pages にデプロイ
- デプロイ URL を PR コメントへ自動投稿
- CI/CD ドキュメントにレポート公開手順を追記

## 確認事項
- `pnpm fullcheck` 実行済み


------
https://chatgpt.com/codex/tasks/task_e_6841ce79a9748326bc69ef92b07842d9